### PR TITLE
Add proof of concept for T.Slog()

### DIFF
--- a/src/testing/slog.go
+++ b/src/testing/slog.go
@@ -1,0 +1,88 @@
+package testing
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"runtime"
+)
+
+// Slog returns a structured logger that writes to the test case output, like t.Log does.
+//
+// TODO: Figure out if we want Slog() behaviour to include the following:
+//
+//	When used with go test -json, any log messages are printed in JSON form.
+//	A TestEvent corresponding to a log message has OutputType "slog", and the Output field contains the JSON text.
+func (t *T) Slog(opts *slog.HandlerOptions) *slog.Logger {
+	return slog.New(t.newOutputHandler(opts))
+}
+
+// outputHandler is a Handler that wraps around TextHandler to
+// format Records as test logs and writes the result to common.output.
+type outputHandler struct {
+	th slog.Handler
+	bb *bytes.Buffer
+	c  *common
+}
+
+// newOutputHandler creates an outputHandler using the given options.
+// If opts is nil, the default options are used.
+func (c *common) newOutputHandler(opts *slog.HandlerOptions) *outputHandler {
+	var b bytes.Buffer
+	return &outputHandler{
+		th: slog.NewTextHandler(&b, opts),
+		bb: &b,
+		c:  c,
+	}
+}
+
+// Handle formats its argument Record as a test log.
+// #TODO: provide specifics when we finalize the approach.
+func (h *outputHandler) Handle(ctx context.Context, r slog.Record) error {
+	err := h.th.Handle(ctx, r)
+	if err != nil {
+		return err
+	}
+
+	pcs := make([]uintptr, 10)
+	n := runtime.Callers(1, pcs[:])
+	f := runtime.CallersFrames(pcs[:n])
+
+	rFrames := runtime.CallersFrames([]uintptr{r.PC})
+	rFrame, _ := rFrames.Next()
+
+	var depth int
+	for {
+		depth++
+
+		frame, more := f.Next()
+		if frame.PC == rFrame.PC {
+			break
+		}
+		if !more {
+			break
+		}
+	}
+
+	h.c.logDepth(h.bb.String(), depth)
+
+	return err
+}
+
+// Enabled reports whether the handler handles records at the given level.
+// The handler ignores records whose level is lower.
+func (h *outputHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.th.Enabled(ctx, level)
+}
+
+// WithAttrs returns a new outputHandler whose attributes consists
+// of h's attributes followed by attrs.
+func (h *outputHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &outputHandler{th: h.th.WithAttrs(attrs)}
+}
+
+// WithGroup returns a new outputHandler with the given group appended to
+// h's existing groups.
+func (h *outputHandler) WithGroup(name string) slog.Handler {
+	return &outputHandler{th: h.th.WithGroup(name)}
+}

--- a/src/testing/slog_test.go
+++ b/src/testing/slog_test.go
@@ -16,13 +16,13 @@ func TestSlog(t *testing.T) {
 		- the indentation of slog output to match t.Log() output
 		- printing of the output under the correct test header
 	*/
-	logger2 := t.Slog()
+	logger2 := t.Slog(nil)
 	logger2.Info("t.Slog log which is indented and which is under parent test header")
 	t.Error("t.Log in parent test for comparison")
 
 	// Additionally, t.Slog() indents slog output depending on the nesting level of the test.
 	t.Run("Subtest", func(t *testing.T) {
-		logger3 := t.Slog()
+		logger3 := t.Slog(nil)
 		logger3.Info("t.Slog log which is indented and which is under subtest header")
 		t.Error("t.Log in subtest for comparison")
 

--- a/src/testing/slog_test.go
+++ b/src/testing/slog_test.go
@@ -9,7 +9,7 @@ import (
 func TestSlog(t *testing.T) {
 	// Slog log lines as they are currently printed out in tests.
 	logger1 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
-	logger1.Info("slog logging in parent test")
+	logger1.Info("slog logging which is not indented and not under parent test header")
 
 	/*
 		t.Slog() allows:
@@ -17,18 +17,18 @@ func TestSlog(t *testing.T) {
 		- printing of the output under the correct test header
 	*/
 	logger2 := t.Slog()
-	logger2.Info("t.Slog log in parent test")
-	t.Error("t.Log in parent test")
+	logger2.Info("t.Slog log which is indented and which is under parent test header")
+	t.Error("t.Log in parent test for comparison")
 
 	// Additionally, t.Slog() indents slog output depending on the nesting level of the test.
 	t.Run("Subtest", func(t *testing.T) {
 		logger3 := t.Slog()
-		logger3.Info("t.Slog log in subtest")
-		t.Error("t.Log in subtest")
+		logger3.Info("t.Slog log which is indented and which is under subtest header")
+		t.Error("t.Log in subtest for comparison")
 
 		// Without t.Slog(), the slog log does not take into account the nesting level.
 		// This is in addition to the log being printed in the wrong section.
 		logger4 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
-		logger4.Info("slog logging in subtest")
+		logger4.Info("slog logging which is not indented and not under subtest header")
 	})
 }

--- a/src/testing/slog_test.go
+++ b/src/testing/slog_test.go
@@ -1,0 +1,34 @@
+package testing_test
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func TestSlog(t *testing.T) {
+	// Slog log lines as they are currently printed out in tests.
+	logger1 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
+	logger1.Info("slog logging in parent test")
+
+	/*
+		t.Slog() allows:
+		- the indentation of slog output to match t.Log() output
+		- printing of the output under the correct test header
+	*/
+	logger2 := t.Slog()
+	logger2.Info("t.Slog log in parent test")
+	t.Error("t.Log in parent test")
+
+	// Additionally, t.Slog() indents slog output depending on the nesting level of the test.
+	t.Run("Subtest", func(t *testing.T) {
+		logger3 := t.Slog()
+		logger3.Info("t.Slog log in subtest")
+		t.Error("t.Log in subtest")
+
+		// Without t.Slog(), the slog log does not take into account the nesting level.
+		// This is in addition to the log being printed in the wrong section.
+		logger4 := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{AddSource: true}))
+		logger4.Info("slog logging in subtest")
+	})
+}

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -376,7 +376,6 @@ import (
 	"internal/goexperiment"
 	"internal/race"
 	"io"
-	"log/slog"
 	"math/rand"
 	"os"
 	"reflect"
@@ -1977,77 +1976,6 @@ func (t *T) report() {
 			t.flushToParent(t.name, format, "PASS", t.name, dstr)
 		}
 	}
-}
-
-// Slog returns a structured logger that writes to the test case output, like t.Log does.
-//
-// TODO: Figure out if we want Slog() behaviour to include the following:
-//
-//	When used with go test -json, any log messages are printed in JSON form.
-//	A TestEvent corresponding to a log message has OutputType "slog", and the Output field contains the JSON text.
-func (t *T) Slog() *slog.Logger {
-	// #TODO refactor the approach overall.
-	return slog.New(slog.NewTextHandler(outputWriter{&t.common}, nil))
-}
-
-type outputWriter struct {
-	c *common
-}
-
-func (s outputWriter) Write(p []byte) (int, error) {
-	// Temporary hack to get the proof of concept working.
-	str := string(p)
-
-	// Code taken almost unchanged from c.logDepth().
-	// The return values are set to default as a quick fix.
-	s.c.mu.Lock()
-	defer s.c.mu.Unlock()
-	if s.c.done {
-		// This test has already finished. Try and log this message
-		// with our parent. If we don't have a parent, panic.
-		for parent := s.c.parent; parent != nil; parent = parent.parent {
-			parent.mu.Lock()
-			defer parent.mu.Unlock()
-			if !parent.done {
-				parent.output = append(parent.output, parent.decorateSlog(str)...)
-				return 0, nil
-			}
-		}
-		panic("Log in goroutine after " + s.c.name + " has completed: " + str)
-	} else {
-		if s.c.chatty != nil {
-			if s.c.bench {
-				// Benchmarks don't print === CONT, so we should skip the test
-				// printer and just print straight to stdout.
-				fmt.Print(s.c.decorateSlog(str))
-			} else {
-				s.c.chatty.Printf(s.c.name, "%s", s.c.decorateSlog(str))
-			}
-
-			return 0, nil
-		}
-		s.c.output = append(s.c.output, s.c.decorateSlog(str)...)
-	}
-	return 0, nil
-}
-
-func (c *common) decorateSlog(s string) string {
-	buf := new(strings.Builder)
-	// Every line is indented at least 4 spaces.
-	buf.WriteString("    ")
-	lines := strings.Split(s, "\n")
-	if l := len(lines); l > 1 && lines[l-1] == "" {
-		lines = lines[:l-1]
-	}
-	for i, line := range lines {
-		if i > 0 {
-			// Second and subsequent lines are indented an additional 4 spaces.
-			buf.WriteString("\n        ")
-		}
-		buf.WriteString(line)
-	}
-	buf.WriteByte('\n')
-	return buf.String()
 }
 
 func listTests(matchString func(pat, str string) (bool, error), tests []InternalTest, benchmarks []InternalBenchmark, fuzzTargets []InternalFuzzTarget, examples []InternalExample) {

--- a/src/testing/testing.go
+++ b/src/testing/testing.go
@@ -376,6 +376,7 @@ import (
 	"internal/goexperiment"
 	"internal/race"
 	"io"
+	"log/slog"
 	"math/rand"
 	"os"
 	"reflect"
@@ -1976,6 +1977,17 @@ func (t *T) report() {
 			t.flushToParent(t.name, format, "PASS", t.name, dstr)
 		}
 	}
+}
+
+// Slog returns a structured logger that writes to the test case output, like t.Log does.
+//
+// TODO: Figure out if we want Slog() behaviour to include the following:
+//
+//	When used with go test -json, any log messages are printed in JSON form.
+//	A TestEvent corresponding to a log message has OutputType "slog", and the Output field contains the JSON text.
+func (t *T) Slog() *slog.Logger {
+	// TODO: Add implementation
+	return nil
 }
 
 func listTests(matchString func(pat, str string) (bool, error), tests []InternalTest, benchmarks []InternalBenchmark, fuzzTargets []InternalFuzzTarget, examples []InternalExample) {


### PR DESCRIPTION
Addresses https://go.dev/issue/59928

<!---
This PR will be imported into Gerrit with the title and first
comment (this text) used to generate the subject and body of
the Gerrit change.

**Please ensure you adhere to every item in this list.**

More info can be found at https://github.com/golang/go/wiki/CommitMessage

+ The PR title is formatted as follows: `net/http: frob the quux before blarfing`
  + The package name goes before the colon
  + The part after the colon uses the verb tense + phrase that completes the blank in,
    "This change modifies Go to ___________"
  + Lowercase verb after the colon
  + No trailing period
  + Keep the title as short as possible. ideally under 76 characters or shorter
+ No Markdown
+ The first PR comment (this one) is wrapped at 76 characters, unless it's
  really needed (ASCII art, table, or long link)
+ If there is a corresponding issue, add either `Fixes #1234` or `Updates #1234`
  (the latter if this is not a complete fix) to this comment
+ If referring to a repo other than `golang/go` you can use the
  `owner/repo#issue_number` syntax: `Fixes golang/tools#1234`
+ We do not use Signed-off-by lines in Go. Please don't add them.
  Our Gerrit server & GitHub bots enforce CLA compliance instead.
+ Delete these instructions once you have read and applied them
--->